### PR TITLE
Update bootstrap-waitingfor.js

### DIFF
--- a/bootstrap-waitingfor.js
+++ b/bootstrap-waitingfor.js
@@ -5,63 +5,103 @@
  */
 
 var waitingDialog = waitingDialog || (function ($) {
-	'use strict';
+    'use strict';
 
-	// Creating modal dialog's DOM
-	var $dialog = $(
-		'<div class="modal fade" data-backdrop="static" data-keyboard="false" tabindex="-1" role="dialog" aria-hidden="true" style="padding-top:15%; overflow-y:visible;">' +
-		'<div class="modal-dialog modal-m">' +
-		'<div class="modal-content">' +
-			'<div class="modal-header"><h3 style="margin:0;"></h3></div>' +
-			'<div class="modal-body">' +
-				'<div class="progress progress-striped active" style="margin-bottom:0;"><div class="progress-bar" style="width: 100%"></div></div>' +
-			'</div>' +
-		'</div></div></div>');
+    // Creating modal dialog's DOM
+    var $dialog = $(
+        '<div class="modal fade" data-backdrop="static" data-keyboard="false" tabindex="-1" role="dialog" aria-hidden="true" style="padding-top:15%; overflow-y:visible;">' +
+            '<div class="modal-dialog modal-m">' +
+                '<div class="modal-content">' +
+                    '<div class="modal-header"></div>' +
+                    '<div class="modal-body">' +
+                        '<div class="progress progress-striped active" style="margin-bottom:0;">' +
+                            '<div class="progress-bar" style="width: 100%"></div>' +
+                        '</div>' +
+                    '</div>' +
+                '</div>' +
+            '</div>' +
+        '</div>');
 
-	return {
-		/**
-		 * Opens our dialog
-		 * @param message Custom message
-		 * @param options Custom options:
-		 * 				  options.dialogSize - bootstrap postfix for dialog size, e.g. "sm", "m";
-		 * 				  options.progressType - bootstrap postfix for progress bar type, e.g. "success", "warning".
-		 */
-		show: function (message, options) {
-			// Assigning defaults
-			if (typeof options === 'undefined') {
-				options = {};
-			}
-			if (typeof message === 'undefined') {
-				message = 'Loading';
-			}
-			var settings = $.extend({
-				dialogSize: 'm',
-				progressType: '',
-				onHide: null // This callback runs after the dialog was hidden
-			}, options);
+    return {
+        /**
+         * Opens our dialog
+         * @param message Custom message
+         * @param options Custom options:
+         * 				  options.dialogSize - bootstrap postfix for dialog size, e.g. "sm", "m";
+         * 				  options.progressType - bootstrap postfix for progress bar type, e.g. "success", "warning".
+         */
+        show: function (message, options) {
+            // Assigning defaults
+            if (typeof options === 'undefined') {
+                options = {};
+            }
+            if (typeof message === 'undefined') {
+                message = 'Loading';
+            }
+            var settings = $.extend({
+                headerText: '',
+                headerSize: 3,
+                headerClass: '',
+                dialogSize: 'm',
+                progressType: '',
+                contentElement: 'p',
+                contentClass: 'content',
+                onHide: null // This callback runs after the dialog was hidden
+            }, options);
 
-			// Configuring dialog
-			$dialog.find('.modal-dialog').attr('class', 'modal-dialog').addClass('modal-' + settings.dialogSize);
-			$dialog.find('.progress-bar').attr('class', 'progress-bar');
-			if (settings.progressType) {
-				$dialog.find('.progress-bar').addClass('progress-bar-' + settings.progressType);
-			}
-			$dialog.find('h3').text(message);
-			// Adding callbacks
-			if (typeof settings.onHide === 'function') {
-				$dialog.off('hidden.bs.modal').on('hidden.bs.modal', function (e) {
-					settings.onHide.call($dialog);
-				});
-			}
-			// Opening dialog
-			$dialog.modal();
-		},
-		/**
-		 * Closes dialog
-		 */
-		hide: function () {
-			$dialog.modal('hide');
-		}
-	};
+            // Configuring dialog
+            $dialog.find('.modal-dialog').attr('class', 'modal-dialog').addClass('modal-' + settings.dialogSize);
+            $dialog.find('.progress-bar').attr('class', 'progress-bar');
+            if (settings.progressType) {
+                $dialog.find('.progress-bar').addClass('progress-bar-' + settings.progressType);
+            }
+
+            // generate header tag
+            var headerTag = $('<h' + settings.headerSize + '></h' + settings.headerSize + '>');
+                headerTag.css({ 'margin-bottom': 0 });
+            if (settings.headerClass.length > 0) {
+                headerTag.addClass(settings.headerClass);
+            }
+
+            // generate content tag
+            var contentTag = $('<' + settings.contentElement + '></' + settings.contentElement + '>');
+            if (settings.contentClass.length > 0) {
+                contentTag.addClass(settings.contentClass);
+            }
+
+            $dialog.find('.modal-header').hide();
+
+            if (settings.headerText === false) {
+                contentTag.html(message);
+                $dialog.find('.modal-body').prepend(contentTag);
+            }
+            else if (settings.headerText.length > 0) {
+                headerTag.html(settings.headerText);
+                $dialog.find('.modal-header').show().append(headerTag);
+
+                contentTag.html(message);
+                $dialog.find('.modal-body').prepend(contentTag);
+            }
+            else {
+                headerTag.html(message);
+                $dialog.find('.modal-header').show().append(headerTag);
+            }
+
+            // Adding callbacks
+            if (typeof settings.onHide === 'function') {
+                $dialog.off('hidden.bs.modal').on('hidden.bs.modal', function (e) {
+                    settings.onHide.call($dialog);
+                });
+            }
+            // Opening dialog
+            $dialog.modal();
+        },
+        /**
+         * Closes dialog
+         */
+        hide: function () {
+            $dialog.modal('hide');
+        }
+    };
 
 })(jQuery);


### PR DESCRIPTION
Added "headerText" option.
The "message" still acts like the header by default. 

**headerText boolean false**
If the option is provided as boolean false, it will hide the header and "message" will be set in a paragraph above the progress bar.

**headerText as not empty string**
When provided a headerText not-empty string, "message" becomes content above the progress bar and the headerText string will be set as text inside the H3.

**Added "headerSize" option.**
This will generate a heading corresponding to the size number. Like ```<h1>, <h2>, <h3>``` etc.
Defaults still set to 3.

**Added "headerClass" option.**
Extra class(es) for the header tag.

**Added "contentElement" option.**
Determines the tag of the content element. Defaults set to 'p', which will generate a ```<p>``` tag.

**Added "contentClass" option.**
Extra class(es) for the content tag.