### PR TITLE
Add instructions to install and require the module using npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,21 @@ See this plugin in action:rocket:: http://bootsnipp.com/snippets/featured/quotwa
 * AMD-compatible
 * Configurable
 
-## Using
+## Installing
+
+### With bower
 
 You can install this module with bower `bower install bootstrap-waitingfor` and include the files from `build` directory.
+
+### With npm
+
+You can install this module typing the command `npm install --save bootstrap-waitingfor` and including as below:
+
+```js
+const waitingDialog = require('bootstrap-waitingfor');
+```
+
+## Using
 
 In your javascript code write something like this:
 ```js


### PR DESCRIPTION
This contribution add support to use the module with npm. The package is already publushed in https://www.npmjs.com/package/bootstrap-waitingfor