### PR TITLE
Extend script to take a nonce for styles

### DIFF
--- a/src/waitingfor.js
+++ b/src/waitingfor.js
@@ -22,25 +22,26 @@
 	/**
 	 * Dialog DOM constructor
 	 */
-	function constructDialog($dialog) {
+	function constructDialog($dialog, settings) {
 		// Deleting previous incarnation of the dialog
 		if ($dialog) {
 			$dialog.remove();
 		}
-		return $(
-			'<div class="modal fade" data-backdrop="static" data-keyboard="false" tabindex="-1" role="dialog" aria-hidden="true" style="padding-top:15%; overflow-y:visible;">' +
+		var nonceAttr = settings.nonce === null ? '' : ' nonce="' + settings.nonce + '"';
+		var elem = $.parseHTML(
+			'<div class="modal fade" data-backdrop="static" data-keyboard="false" tabindex="-1" role="dialog" aria-hidden="true" style="padding-top:15%; overflow-y:visible;"' + nonceAttr + '>' +
 				'<div class="modal-dialog modal-m">' +
 					'<div class="modal-content">' +
-						'<div class="modal-header" style="display: none;"></div>' +
+						'<div class="modal-header" style="display: none;"' + nonceAttr + '></div>' +
 						'<div class="modal-body">' +
-							'<div class="progress progress-striped active" style="margin-bottom:0;">' +
-								'<div class="progress-bar" style="width: 100%"></div>' +
+							'<div class="progress progress-striped active" style="margin-bottom:0;"' + nonceAttr + '>' +
+								'<div class="progress-bar" style="width: 100%"' + nonceAttr + '></div>' +
 							'</div>' +
 						'</div>' +
 					'</div>' +
 				'</div>' +
-			'</div>'
-		);
+			'</div>');
+		return $(elem);
 	}
 
 	var $dialog, // Dialog object
@@ -80,12 +81,13 @@
 				contentElement: 'p',
 				contentClass: 'content',
 				onHide: null, // This callback runs after the dialog was hidden
-				onShow: null // This callback runs after the dialog was shown
+				onShow: null, // This callback runs after the dialog was shown
+				nonce: null // Nonce to permit inline styles
 			}, options);
 
 			var $headerTag, $contentTag;
 
-			$dialog = constructDialog($dialog);
+			$dialog = constructDialog($dialog, settings);
 
 			// Configuring dialog
 			$dialog.find('.modal-dialog').attr('class', 'modal-dialog').addClass('modal-' + settings.dialogSize);


### PR DESCRIPTION
Exactly as described in #33. Extends the script to take a nonce which is included with the generated elements to permit their inline styles to be applied by the browser in the presence of a CSP. If no nonce is specified, the generated element is unaffected:

```html
<div class="modal fade" data-backdrop="static" data-keyboard="false" tabindex="-1" role="dialog" aria-hidden="true" style="padding-top:15%; overflow-y:visible;"> 
	<div class="modal-dialog modal-m"> 
		<div class="modal-content"> 
			<div class="modal-header" style="display: none;"></div> 
			<div class="modal-body"> 
				<div class="progress progress-striped active" style="margin-bottom:0;"> 
					<div class="progress-bar" style="width: 100%"></div> 
				</div> 
			</div> 
		</div> 
	</div> 
</div>
```

If a nonce (e.g. `QVd4OVVMODdkQ0xm`) is specified (as an entry in `options`) however, we get this:

```html
<div class="modal fade" data-backdrop="static" data-keyboard="false" tabindex="-1" role="dialog" aria-hidden="true" style="padding-top:15%; overflow-y:visible;" nonce="QVd4OVVMODdkQ0xm"> 
	<div class="modal-dialog modal-m"> 
		<div class="modal-content"> 
			<div class="modal-header" style="display: none;" nonce="QVd4OVVMODdkQ0xm"></div> 
			<div class="modal-body"> 
				<div class="progress progress-striped active" style="margin-bottom:0;" nonce="QVd4OVVMODdkQ0xm"> 
					<div class="progress-bar" style="width: 100%" nonce="QVd4OVVMODdkQ0xm"></div> 
				</div> 
			</div> 
		</div> 
	</div> 
</div>
```

Now our CSP can specify `style-src: nonce-QVd4OVVMODdkQ0xm` and our inline styles will work just fine. This nonce must be a cryptographically secure random value >=128 bits in length to prevent prediction/guessing.